### PR TITLE
Allow students to delete uploaded files

### DIFF
--- a/coralx-frontend/components/course/ModuleStream.tsx
+++ b/coralx-frontend/components/course/ModuleStream.tsx
@@ -697,25 +697,36 @@ export function ModuleStream({
     // This would call an API endpoint to personalize all files in the module
   };
 
-  const handleDeleteMaterial = (materialId: string) => {
-    // Optimistic update
-    setModules(prev => 
+  const handleDeleteMaterial = async (materialId: string) => {
+    const deleteToast = toast.loading("Deleting file...");
+
+    // Optimistically remove from UI
+    setModules(prev =>
       prev.map(module => ({
         ...module,
         materials: module.materials.filter(m => m.id !== materialId)
       }))
     );
-    
-    toast.success("File deleted", {
-      description: "Move to trash? Undo",
-      action: {
-        label: "Undo",
-        onClick: () => {
-          // TODO: Implement proper undo
-          window.location.reload(); // Temporary solution
-        }
+
+    try {
+      const endpoint = userRole === 'student'
+        ? `/student/files/${materialId}`
+        : `/instructor/files/${materialId}`;
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8081'}${endpoint}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to delete file: ${response.statusText}`);
       }
-    });
+
+      toast.success("File deleted", { id: deleteToast });
+    } catch (error) {
+      console.error('Failed to delete file:', error);
+      toast.error("Failed to delete file", { id: deleteToast });
+    }
   };
 
   const getFileIcon = (type: Material["type"]) => {

--- a/coralx-frontend/components/dashboard/ProfessorDash.tsx
+++ b/coralx-frontend/components/dashboard/ProfessorDash.tsx
@@ -18,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { instructorAPI } from "@/lib/api";
 import {
   Dialog,
   DialogContent,
@@ -461,15 +462,7 @@ export default function ProfessorDashboard() {
 
   const handleDeleteCourse = async (deletedCourse: any) => {
     try {
-      const res = await fetch(
-        `http://localhost:8080/instructor/courses/${deletedCourse.id}`,
-        {
-          method: "DELETE",
-          credentials: "include",
-        }
-      );
-
-      if (!res.ok) throw new Error("Failed to delete course");
+      await instructorAPI.deleteCourse(deletedCourse.id);
 
       setCourses((prev) => prev.filter((c) => c.id !== deletedCourse.id));
       setSelectedCourse(null); // Navigates back to dashboard view

--- a/coralx-frontend/lib/api.ts
+++ b/coralx-frontend/lib/api.ts
@@ -210,6 +210,7 @@ export const studentAPI = {
     });
   },
   getFileContent: (fileId: string) => api.get(`/student/files/${fileId}/content`),
+  deleteFile: (fileId: string) => api.delete(`/student/files/${fileId}`),
   getFileUrl: async (fileId: string) => {
     try {
       // For direct file access, we need to use the API call to get proper authentication
@@ -234,6 +235,9 @@ export const studentAPI = {
       throw new Error('File not accessible');
     }
   },
+
+  // Personalized files
+  deletePersonalizedFile: (pfId: string) => api.delete(`/student/personalized-files/${pfId}`),
   
   // Submissions
   submitAssignment: (assignmentId: string, data: any) => api.post(`/student/assignments/${assignmentId}/submit`, data),

--- a/docker-image/src/app.py
+++ b/docker-image/src/app.py
@@ -525,6 +525,60 @@ def instructor_courses():
     for c in courses
 ]), 200
 
+
+@app.route('/instructor/courses/<course_id>', methods=['GET', 'PATCH', 'DELETE'])
+def instructor_manage_course(course_id):
+    """Manage a single course owned by the instructor"""
+    user_id, err = verify_instructor()
+    if err:
+        return err
+
+    db = Session()
+    try:
+        course = get_course_by_id(db, course_id)
+        if not course or str(course.instructor_id) != str(user_id):
+            db.close()
+            return jsonify({'error': 'Course not found or access denied'}), 404
+
+        if request.method == 'GET':
+            return jsonify({
+                'id': str(course.id),
+                'title': course.title,
+                'description': course.description,
+                'code': course.code,
+                'term': course.term,
+                'published': course.published,
+                'created_at': course.created_at.isoformat() if course.created_at else None,
+                'last_updated': course.last_updated.isoformat() if course.last_updated else None
+            }), 200
+
+        elif request.method == 'PATCH':
+            data = request.get_json() or {}
+            allowed_fields = ['title', 'description', 'code', 'term', 'published']
+            update_data = {k: v for k, v in data.items() if k in allowed_fields}
+
+            if not update_data:
+                db.close()
+                return jsonify({'error': 'No valid fields to update'}), 400
+
+            updated_course = update_course(db, course_id, **update_data)
+            db.commit()
+            return jsonify({
+                'id': str(updated_course.id),
+                'message': 'Course updated successfully'
+            }), 200
+
+        elif request.method == 'DELETE':
+            delete_course(db, course_id)
+            db.commit()
+            return jsonify({'message': 'Course deleted successfully'}), 200
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'error': str(e)}), 500
+    finally:
+        db.close()
+
 @app.route('/student/courses/<course_id>', methods=['GET', 'PATCH', 'DELETE'])
 def student_manage_course(course_id):
     user_id, err = verify_student()
@@ -787,28 +841,37 @@ def generate_personalized_file_content():
                 pass
         return jsonify({"error": str(e)}), 500
 
-@app.route('/student/personalized-files/<pf_id>', methods=['GET'])
-def get_student_personalized_file(pf_id):
+@app.route('/student/personalized-files/<pf_id>', methods=['GET', 'DELETE'])
+def student_manage_personalized_file(pf_id):
     user_id, err = verify_student()
     if err:
         return err
 
     db = Session()
-    pf = get_personalized_file_by_id(db, pf_id)
+    try:
+        pf = get_personalized_file_by_id(db, pf_id)
 
-    if not pf or str(pf.user_id) != str(user_id):
+        if not pf or str(pf.user_id) != str(user_id):
+            return jsonify({'error': 'Not found or unauthorized'}), 404
+
+        if request.method == 'GET':
+            response = {
+                'id': str(pf.id),
+                'originalFileId': str(pf.original_file_id) if pf.original_file_id else None,
+                'createdAt': pf.created_at.isoformat(),
+                'content': pf.content
+            }
+            return jsonify(response), 200
+
+        elif request.method == 'DELETE':
+            delete_personalized_file(db, pf_id)
+            return jsonify({'message': 'Personalized file deleted successfully'}), 200
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'error': str(e)}), 500
+    finally:
         db.close()
-        return jsonify({'error': 'Not found or unauthorized'}), 404
-
-    response = {
-        'id': str(pf.id),
-        'originalFileId': str(pf.original_file_id) if pf.original_file_id else None,
-        'createdAt': pf.created_at.isoformat(),
-        'content': pf.content  
-    }
-
-    db.close()
-    return jsonify(response), 200
 
 @app.route('/student/chats', methods=['GET', 'POST'])
 def student_chats():
@@ -2600,36 +2663,66 @@ def student_file_download(file_id):
         }
     )
 
-@app.route('/student/files/<file_id>', methods=['GET'])
-def student_file_info(file_id):
+@app.route('/student/files/<file_id>', methods=['GET', 'PATCH', 'DELETE'])
+def student_manage_file(file_id):
     user_id, err = verify_student()
     if err:
         return err
 
     db = Session()
+    try:
+        f = get_file_by_id(db, file_id)
+        if not f:
+            return jsonify({'error': 'Not found'}), 404
 
-    f = get_file_by_id(db, file_id)
-    if not f:
+        mod = get_module_by_id(db, f.module_id)
+        if not mod:
+            return jsonify({'error': 'Module not found'}), 404
+
+        course = get_course_by_id(db, mod.course_id)
+        if not course or str(course.creator_id) != str(user_id):
+            return jsonify({'error': 'Forbidden'}), 403
+
+        if request.method == 'GET':
+            response = {
+                'id': str(f.id),
+                'title': f.title,
+                'filename': f.filename,
+                'file_type': f.file_type,
+                'file_size': f.file_size,
+                'module_id': str(f.module_id),
+                'created_at': f.created_at.isoformat() if f.created_at else None
+            }
+            return jsonify(response), 200
+
+        elif request.method == 'PATCH':
+            data = request.get_json() or {}
+            allowed_fields = ['title']
+            update_data = {k: v for k, v in data.items() if k in allowed_fields}
+
+            if not update_data:
+                return jsonify({'error': 'No valid fields to update'}), 400
+
+            updated_file = update_file(db, file_id, **update_data)
+            return jsonify({
+                'id': str(updated_file.id),
+                'title': updated_file.title,
+                'filename': updated_file.filename,
+                'file_type': updated_file.file_type,
+                'file_size': updated_file.file_size,
+                'module_id': str(updated_file.module_id),
+                'created_at': updated_file.created_at.isoformat() if updated_file.created_at else None
+            }), 200
+
+        elif request.method == 'DELETE':
+            delete_file(db, file_id)
+            return jsonify({'message': 'File deleted successfully'}), 200
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'error': str(e)}), 500
+    finally:
         db.close()
-        return jsonify({'error': 'Not found'}), 404
-
-    mod = get_module_by_id(db, f.module_id)
-    if not mod or not get_enrollment_by_student_course(db, user_id, mod.course_id):
-        db.close()
-        return jsonify({'error': 'Forbidden'}), 403
-
-    response = {
-        'id': str(f.id),
-        'title': f.title,
-        'filename': f.filename,
-        'file_type': f.file_type,
-        'file_size': f.file_size,
-        'module_id': str(f.module_id),
-        'created_at': f.created_at.isoformat() if f.created_at else None
-    }
-    
-    db.close()
-    return jsonify(response), 200
 
 # ===== NEW INSTRUCTOR FILE & MODULE MANAGEMENT ENDPOINTS =====
 


### PR DESCRIPTION
## Summary
- enable deletion of personalized files and uploads for students
- add student API helpers for deleting files
- use DELETE endpoint in ModuleStream

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*