### PR TITLE
Enable module-aware student uploads

### DIFF
--- a/coralx-frontend/app/courses/[courseId]/page.tsx
+++ b/coralx-frontend/app/courses/[courseId]/page.tsx
@@ -163,6 +163,7 @@ export default function CoursePage() {
   const searchParams = useSearchParams();
   const courseId = params?.courseId as string;
   const activeTab = searchParams?.get("tab") || "home";
+  const selectedModuleId = searchParams?.get("moduleId") || undefined;
 
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isFocusMode, setIsFocusMode] = useState(false);
@@ -1357,8 +1358,9 @@ export default function CoursePage() {
           </DialogHeader>
           
           {useAdvancedUpload && currentUser?.role === 'student' ? (
-            <StudentCourseUpload 
+            <StudentCourseUpload
               courseId={courseId}
+              moduleId={selectedModuleId}
               onUploadComplete={handleUploadComplete}
             />
           ) : (

--- a/coralx-frontend/components/course/StudentCourseUpload.tsx
+++ b/coralx-frontend/components/course/StudentCourseUpload.tsx
@@ -36,11 +36,12 @@ interface UploadFile {
 
 interface StudentCourseUploadProps {
   courseId?: string; // Optional - if provided, upload to existing course
+  moduleId?: string; // Optional - specify module/week for upload
   onUploadComplete?: (result: any) => void;
   className?: string;
 }
 
-export function StudentCourseUpload({ courseId, onUploadComplete, className }: StudentCourseUploadProps) {
+export function StudentCourseUpload({ courseId, moduleId, onUploadComplete, className }: StudentCourseUploadProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
   const [activeTab, setActiveTab] = useState("files");
@@ -148,6 +149,9 @@ export function StudentCourseUpload({ courseId, onUploadComplete, className }: S
       formData.append('file', uploadFile.file);
       formData.append('title', uploadFile.file.name);
       formData.append('description', `Student upload: ${uploadFile.file.name}`);
+      if (moduleId) {
+        formData.append('moduleId', moduleId);
+      }
       
       // Upload to student's course
       const result = await studentAPI.uploadFile(courseId, formData);


### PR DESCRIPTION
## Summary
- allow StudentCourseUpload to accept a `moduleId` prop
- include optional `moduleId` in file upload form data
- read `moduleId` from search parameters in course page
- pass `moduleId` to `StudentCourseUpload` when uploading materials

## Testing
- `npm run lint` *(fails: `next` not found)*
- `python3 test_delete.py` *(fails: ModuleNotFoundError)*