### PR TITLE
Fix empty todo list handling

### DIFF
--- a/coralx-frontend/components/course/StatsSidePanel.tsx
+++ b/coralx-frontend/components/course/StatsSidePanel.tsx
@@ -87,16 +87,17 @@ export function StatsSidePanel({
         
         // Use real API call instead of mock data
         const response = await studentAPI.getTodoItems();
-        console.log('StatsSidePanel: Loaded todos from API:', response?.length || 0, 'items');
-        
+        const todosData: TodoItem[] = Array.isArray(response) ? response : [];
+        console.log('StatsSidePanel: Loaded todos from API:', todosData.length, 'items');
+
         // Filter todos for this specific course if we have a course ID
-        const courseTodos = course?.id 
-          ? response.filter((todo: TodoItem) => 
-              todo.course === course.title || 
+        const courseTodos = course?.id
+          ? todosData.filter((todo: TodoItem) =>
+              todo.course === course?.title ||
               todo.course === 'General' ||
               todo.course === 'This Course'
             )
-          : response;
+          : todosData;
         
         console.log('StatsSidePanel: Filtered todos for course:', courseTodos?.length || 0, 'items');
         setTodos(courseTodos);

--- a/coralx-frontend/components/dashboard/ModernDashboard.tsx
+++ b/coralx-frontend/components/dashboard/ModernDashboard.tsx
@@ -165,8 +165,9 @@ export default function ModernDashboard({ userRole, currentUser, courses = [] }:
       console.log('Loading todo items from API...');
       if (userRole === 'student') {
         const realTodos = await studentAPI.getTodoItems();
-        console.log('Loaded todos from API:', realTodos?.length || 0, 'items');
-        setTodoItems(realTodos || []);
+        const todosData: TodoItem[] = Array.isArray(realTodos) ? realTodos : [];
+        console.log('Loaded todos from API:', todosData.length, 'items');
+        setTodoItems(todosData);
       } else {
         // For instructors/admins, show empty or instructor-specific todos
         setTodoItems([]);

--- a/docker-image/src/app.py
+++ b/docker-image/src/app.py
@@ -2019,99 +2019,9 @@ def student_todo_items():
                     'completed': todo.completed
                 })
             
-            # If no todos exist, create some helpful default ones
+            # If no todos exist, return an empty list instead of defaults
             if not todo_items:
-                # Get courses student is enrolled in to create course-specific todos
-                try:
-                    enrollments = get_enrollments_by_student(db, user_id)
-                    
-                    for enrollment in enrollments:
-                        course = get_course_by_id(db, enrollment.course_id)
-                        if course:
-                            # Create a default todo for exploring the course
-                            todo = create_todo(
-                                db, 
-                                user_id=user_id,
-                                course_id=str(course.id),
-                                title=f"Explore {course.title}",
-                                description=f"Get familiar with the course materials and structure",
-                                todo_type='reading',
-                                priority='medium'
-                            )
-                            todo_items.append({
-                                'id': str(todo.id),
-                                'title': todo.title,
-                                'description': todo.description,
-                                'course': course.title,
-                                'dueDate': 'This week',
-                                'type': todo.todo_type,
-                                'priority': todo.priority,
-                                'completed': todo.completed
-                            })
-                except Exception as e:
-                    print(f"Error creating default course todos: {str(e)}")
-                
-                # Check for personalized files that suggest practice
-                try:
-                    personalized_files = get_personalized_files_by_student(db, user_id)
-                    if personalized_files and len(personalized_files) > 0:
-                        todo = create_todo(
-                            db,
-                            user_id=user_id,
-                            title='Continue AI-assisted learning',
-                            description='Review your personalized learning materials',
-                            todo_type='quiz',
-                            priority='high'
-                        )
-                        todo_items.append({
-                            'id': str(todo.id),
-                            'title': todo.title,
-                            'description': todo.description,
-                            'course': 'Course Materials',
-                            'dueDate': 'Soon',
-                            'type': todo.todo_type,
-                            'priority': todo.priority,
-                            'completed': todo.completed
-                        })
-                except Exception as e:
-                    print(f"Error creating personalized file todo: {str(e)}")
-                
-                # If still no todos, create basic getting started ones
-                if not todo_items:
-                    default_todos = [
-                        {
-                            'title': 'Explore your course materials',
-                            'description': 'Browse through your enrolled courses and available materials',
-                            'todo_type': 'reading',
-                            'priority': 'medium'
-                        },
-                        {
-                            'title': 'Upload some study materials',
-                            'description': 'Add your own documents to enhance your learning experience',
-                            'todo_type': 'upload',
-                            'priority': 'low'
-                        }
-                    ]
-                    
-                    for default_todo in default_todos:
-                        todo = create_todo(
-                            db,
-                            user_id=user_id,
-                            title=default_todo['title'],
-                            description=default_todo['description'],
-                            todo_type=default_todo['todo_type'],
-                            priority=default_todo['priority']
-                        )
-                        todo_items.append({
-                            'id': str(todo.id),
-                            'title': todo.title,
-                            'description': todo.description,
-                            'course': 'Getting Started',
-                            'dueDate': 'Today',
-                            'type': todo.todo_type,
-                            'priority': todo.priority,
-                            'completed': todo.completed
-                        })
+                return jsonify([]), 200
             
             return jsonify(todo_items), 200
             
@@ -2170,16 +2080,8 @@ def student_todo_items():
             
     except Exception as e:
         print(f"Todo items error: {str(e)}")
-        # Return helpful defaults instead of error
-        return jsonify([{
-            'id': 'default-todo',
-            'title': 'Start exploring your learning platform',
-            'course': 'Getting Started',
-            'dueDate': 'Today',
-            'type': 'reading',
-            'priority': 'medium',
-            'completed': False
-        }]), 200
+        # Return an empty list on error instead of mock data
+        return jsonify([]), 200
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary
- return an empty list from `/student/todo-items` when there are no tasks or errors
- ensure dashboard handles undefined todo arrays
- prevent StatsSidePanel from assuming data when todos are empty

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for sqlalchemy)*