### PR TITLE
Enable module-aware student uploads

### DIFF
--- a/coralx-frontend/app/courses/[courseId]/page.tsx
+++ b/coralx-frontend/app/courses/[courseId]/page.tsx
@@ -163,6 +163,7 @@ export default function CoursePage() {
   const searchParams = useSearchParams();
   const courseId = params?.courseId as string;
   const activeTab = searchParams?.get("tab") || "home";
+  const selectedModuleId = searchParams?.get("moduleId") || undefined;
 
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isFocusMode, setIsFocusMode] = useState(false);
@@ -1357,8 +1358,9 @@ export default function CoursePage() {
           </DialogHeader>
           
           {useAdvancedUpload && currentUser?.role === 'student' ? (
-            <StudentCourseUpload 
+            <StudentCourseUpload
               courseId={courseId}
+              moduleId={selectedModuleId}
               onUploadComplete={handleUploadComplete}
             />
           ) : (

--- a/coralx-frontend/components/course/StudentCourseUpload.tsx
+++ b/coralx-frontend/components/course/StudentCourseUpload.tsx
@@ -36,11 +36,12 @@ interface UploadFile {
 
 interface StudentCourseUploadProps {
   courseId?: string; // Optional - if provided, upload to existing course
+  moduleId?: string; // Optional - specify module/week for upload
   onUploadComplete?: (result: any) => void;
   className?: string;
 }
 
-export function StudentCourseUpload({ courseId, onUploadComplete, className }: StudentCourseUploadProps) {
+export function StudentCourseUpload({ courseId, moduleId, onUploadComplete, className }: StudentCourseUploadProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
   const [activeTab, setActiveTab] = useState("files");
@@ -148,9 +149,13 @@ export function StudentCourseUpload({ courseId, onUploadComplete, className }: S
       formData.append('file', uploadFile.file);
       formData.append('title', uploadFile.file.name);
       formData.append('description', `Student upload: ${uploadFile.file.name}`);
+      if (moduleId) {
+        formData.append('moduleId', moduleId);
+      }
       
-      // Upload to student's course
-      const result = await studentAPI.uploadFile(courseId, formData);
+      // Upload to student's course and parse JSON response
+      const response = await studentAPI.uploadFile(courseId, formData);
+      const result = await response.json();
 
       // Simulate progress during upload
       let progress = 0;
@@ -175,8 +180,18 @@ export function StudentCourseUpload({ courseId, onUploadComplete, className }: S
             : f
         ));
 
-        // Call success callback
-        onUploadComplete?.(result);
+        // Call success callback with normalized data for parent components
+        onUploadComplete?.({
+          id: result.id,
+          title: uploadFile.file.name,
+          type: uploadFile.file.type.includes('pdf') ? 'pdf' :
+                uploadFile.file.type.includes('audio') ? 'audio' :
+                uploadFile.file.type.includes('video') ? 'video' : 'document',
+          size: formatFileSize(uploadFile.file.size),
+          uploadedAt: 'Just now',
+          processed: true,
+          moduleId: result.module_id || moduleId,
+        });
         sonnerToast.success(`${uploadFile.file.name} uploaded successfully!`);
       }, 2000);
 


### PR DESCRIPTION
## Summary
- allow StudentCourseUpload to accept a `moduleId` prop
- include optional `moduleId` in file upload form data
- parse JSON response and normalize returned file info
- read `moduleId` from search parameters in course page
- pass `moduleId` to `StudentCourseUpload` when uploading materials

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `python3 test_delete.py` *(fails: ModuleNotFoundError)*